### PR TITLE
fix: change typo in mapped NIST control

### DIFF
--- a/applications/openshift/integrity/file_integrity_exists/rule.yml
+++ b/applications/openshift/integrity/file_integrity_exists/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 
 references:
   nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-007-3 R4,CIP-007-3 R4.1,CIP-007-3 R4.2
-  nist: SC-4(23),SI-6,SI-7,SI-7(1),CM-6(a),SI-7(2),SI-4(24)
+  nist: SI-4(23),SI-6,SI-7,SI-7(1),CM-6(a),SI-7(2),SI-4(24)
   pcidss: Req-10.5.5,Req-11.5
   srg: SRG-APP-000516-CTR-001325
 


### PR DESCRIPTION
correct NIST control from SC-4(23) to SI-4(23). Original NIST control does not exist in any NIST 800-53 revision. Fixes issue #13678
